### PR TITLE
switch to fsleyes panel instead of matplotlib figure

### DIFF
--- a/python/asl/gui/__init__.py
+++ b/python/asl/gui/__init__.py
@@ -83,8 +83,11 @@ class AslGui(wx.Frame):
             for tab2 in tabs:
                 if tab != tab2: setattr(tab, tab2.name, tab2)
             tab.update()
-
         self.Layout()
+        self.Bind(wx.EVT_CLOSE, self.onClose, self)
+
+    def onClose(self, event):
+        wx.GetApp().ExitMainLoop()
 
 def main():
     app = wx.App(redirect=False)
@@ -93,4 +96,4 @@ def main():
     app.MainLoop()
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/python/asl/gui/run_box.py
+++ b/python/asl/gui/run_box.py
@@ -180,13 +180,10 @@ class AslRun(wx.Frame):
             cmd.add('--mean="%s"' % meanfile)
             cmd.add(" ".join(self.get_data_order_options()))
             cmd.run()
-            img = nib.load(meanfile)
-            return img.get_data()
+            return meanfile
         except:
             traceback.print_exc()
             return None
-        finally:
-            shutil.rmtree(tempdir)
 
     def get_data_order_options(self):
         """


### PR DESCRIPTION
hi @mcraig-ibme,

I've been working on making new wxpython versions of all of FSL's outdated guis. I'm in FMRIB with Paul and Matthew. 

Recently, with Paul's FSLeyes help, I've been putting embeded FSLeyes orthopanels in the newer GUIs where it makes sense. It's quite a nice feature to be able to quickly preview any image within a GUI rather than opening a separate FSLeyes window to do so. 

This pull request changes the asl_gui preview panel from a matplotlib figure, to a FSLeyes orthopanel that is interactive. 

it relies on at least `fsleyes-0.32.3` and `fslpy-3.0.0`

These are necessary added dependencies, but since other parts of FSL are needed as well for some bits of ASL, it's likely that these packages would be available anyways with a normal FSL installation (at least the next FSL 6.0.4 with updated fsleyes and fslpy versions). 

I have tested it with a non-conda python3.7 virtual environment, and FSL's `fslpythonw `environment with updated `fsleyes` and `fslpy`

A screenshot is attached so you can see what a preview looks like now. 

Lastly, there are a few functions that you had used for updating and redrawing the matplotlib figure. I have simply left those in with "hacky" returns for now. If you guys want to go forward and switch to using FSLeyes panels then it would be best to clean these small hacks up. 

I wanted to share this as a proof of concept, with the intention of making it cleaner and robust once you're happy with the implementation. 

<img width="1555" alt="Screenshot 2020-04-02 at 17 04 11" src="https://user-images.githubusercontent.com/5217720/78271931-b7ab5780-7504-11ea-855f-d254ac35efe9.png">
