### PR TITLE
Rf/fsleyes wxpython compat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,4 +55,4 @@ clean:
 	rm -f ${VERSIONED} asl_file *.o
 
 FORCE:
-	python python/setup.py build
+	fslpython python/setup.py build

--- a/python/oxford_asl/gui/preview_fsleyes.py
+++ b/python/oxford_asl/gui/preview_fsleyes.py
@@ -15,7 +15,6 @@ import fsleyes.overlay as fsloverlay
 import fsleyes.displaycontext as fsldc
 import fsleyes.views.orthopanel as orthopanel
 import fsleyes.profiles as profiles
-import fsleyes.profiles.profilemap as profilemap
 import fsleyes.colourmaps as colourmaps
 
 from fsl.utils.platform import platform as fslplatform

--- a/python/oxford_asl/gui/widgets.py
+++ b/python/oxford_asl/gui/widgets.py
@@ -362,8 +362,8 @@ class NumberChooser(wx.Panel):
         self.slider = wx.Slider(self, value=initial, minValue=0, maxValue=100)
         self.slider.SetValue(100*(initial-self.minval)/(self.maxval-self.minval))
         self.slider.Bind(wx.EVT_SLIDER, self._slider_changed)
-        self.hbox.Add(self.slider, proportion=1, flag=wx.EXPAND | wx.ALIGN_CENTRE_VERTICAL)
-        self.hbox.Add(self.spin, proportion=0, flag=wx.EXPAND | wx.ALIGN_CENTRE_VERTICAL)
+        self.hbox.Add(self.slider, proportion=1, flag=wx.EXPAND)
+        self.hbox.Add(self.spin, proportion=0, flag=wx.EXPAND)
         self.SetSizer(self.hbox)
 
     def GetValue(self):


### PR DESCRIPTION
Hi @mcraig-ibme, this PR has a couple of small compatibility fixes:

 - The `fsleyes.profiles.profilemap` module no longer exists as of FSLeyes >=1.0.0 (and wasn't used by `preview_fsleyes.py` anyway)
 - As of wxpython >=4.1 `wx.Sizer` objects will raise an error when given both `wx.EXPAND` and vertical alignment flags
 - Use `fslpython` in the Makefile, rather than `python`, as the latter may not have `setuptools` installed (e.g. if it is an old system python)

Thanks!