### PR TITLE
MNT: Revert fslpython back to python for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,4 +55,4 @@ clean:
 	rm -f ${VERSIONED} asl_file *.o
 
 FORCE:
-	fslpython python/setup.py build
+	python python/setup.py build


### PR DESCRIPTION
Hi @mcraig-ibme, sorry for the hassle, but it turns out that, for FSL 6.0.5, `fslpython` is not installed at build time, so we have to depend on a `python` executable being present.

But when we move to conda (hopefully within the next couple of months) there is guaranteed to be a `fslpython` executable present at build time (as it is one of the first things that is installed). So I'll add this change to my `mnt/conda` branch. Sorry again!