### PR TITLE
RF: Set initial choice selection after call to pack

### DIFF
--- a/python/oxford_asl/gui/widgets.py
+++ b/python/oxford_asl/gui/widgets.py
@@ -144,7 +144,6 @@ class TabPage(wx.Panel, OptionComponent):
         if not handler:
             handler = self.state_changed
         choice = wx.Choice(self, choices=choices)
-        choice.SetSelection(initial)
         choice.Bind(wx.EVT_CHOICE, handler)
         if optional:
             checkbox = wx.CheckBox(self, label=label)
@@ -155,6 +154,7 @@ class TabPage(wx.Panel, OptionComponent):
                 self.pack("", checkbox, choice, enable=initial_on, **kwargs)
         elif pack:
             self.pack(label, choice, **kwargs)
+        choice.SetSelection(initial)
         return choice
 
     def number(self, label, handler=None, **kwargs):


### PR DESCRIPTION
Hi @mcraig-ibme, I've come across some slightly strange behaviour under macOS Catalina / wxpython 4.1.1 with regard to the initial selection for `wx.Choice` widgets. This problem does not occur with wxpython 4.0.7.post2.

Basically, the initial selection for `wx.Choice` widgets is not being applied, as depicted below:

![image](https://user-images.githubusercontent.com/236128/141512665-2497a795-8909-494e-b8c7-a11b88440a24.png)

A little debugging led me to the [`widget.SetFont()` call in the`oxford_asl.gui.widgets:TabPage.pack` function](https://github.com/physimals/oxford_asl/blob/02f985990c79ae2e028dcb85b3015cfdc5f2fad8/python/oxford_asl/gui/widgets.py#L90). Before this call, calling `wx.Choice.GetSelection` on the widget will return the initial selection value, but after the call will return -1.

This PR simply moves the inital call to `choice.SetSelection(initial)` after the call to `self.pack`, to work around this strange behaviour.
