### PR TITLE
BF: console scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ else
 endif
 
 XFILES    = asl_file
-SCRIPTS   = oxford_asl asl_calib asl_reg quasil toast oxford_asl_roi_stats.py oxford_asl_hadamard_decode.py
+SCRIPTS   = oxford_asl asl_calib asl_reg quasil toast
 PYMODULES = python/oxford_asl/*.py
 PYGUI     = python/oxford_asl/gui/*.py python/oxford_asl/gui/*.png
 VERSIONED = oxford_asl asl_calib quasil asl_reg toast
@@ -57,7 +57,7 @@ postinstallscript: $(PYMODULES) $(PYGUI)
 # of _version.py before installation
 pyinstall:
 	fslpython python/setup.py -V
-	fslpython -m pip install --no-deps -vv ./python/
+	fslpython -m pip install --no-deps -vv ./python/ --prefix ${FSLDEVDIR}
 
 clean:
 	rm -f ${VERSIONED} asl_file *.o

--- a/python/setup.py
+++ b/python/setup.py
@@ -106,11 +106,11 @@ kwargs = {
         'gui_scripts' : [
             "asl_gui=oxford_asl.gui.main:main",
         ],
-    },
         'console_scripts' : [
             "oxford_asl_roi_stats=oxford_asl.roi_stats:main",
             "oxford_asl_hadamard_decode=oxford_asl.hadamard_decode:main",
         ],
+    },
     'classifiers' : [
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
Hi @mcraig-ibme, I've just come across a quirk in the oxford_asl build process - the `oxford_asl_roi_stats` and `oxford_asl_hadamard_decode` executables were not being created in `$FSLDIR/bin/` due to a typo in `setup.py`.

I've also changed the python install command to set `--prefix $[FSLDEVDIR]`, for local development (for FSL >= 6.0.6 releases) - if you add this [sitecustomize.py](https://git.fmrib.ox.ac.uk/fsl/base/-/blob/master/etc/fslconf/sitecustomize.py) file into your `$FSLDIR/lib/pythonX.Y/site-packages/` directory, then `$FSLDEVDIR/lib/pythonX.Y/site-packages/` to the `fslpython` module search path. This `sitecustomize.py` file does not get installed automatically at present (you can find a copy of it in `$FSLDIR/etc/fslconf/`), but we may update the `fslinstaller.py` script to do so at some point.

Thanks!