### PR TITLE
MNT: Nifti1Image.get_data raises an error in nibabel 5

### DIFF
--- a/python/oxford_asl/gui/__init__.py
+++ b/python/oxford_asl/gui/__init__.py
@@ -96,7 +96,7 @@ class OptionComponent():
             raise OptionError("%s - failed to load file - is this a valid image file?" % label)
 
         try:
-            return nii.get_data().shape
+            return nii.get_fdata().shape
         except:
             raise OptionError("%s - failed to read data shape - check image file is not corrupted")
 
@@ -161,7 +161,7 @@ def get_nvols(fname):
     :return Number of volumes or -1 if could not read the file for any reason
     """
     try:
-        shape = nib.load(fname).get_data().shape
+        shape = nib.load(fname).get_fdata().shape
         if len(shape) == 4:
             return shape[3]
         else:

--- a/python/oxford_asl/gui/preview_fsleyes.py
+++ b/python/oxford_asl/gui/preview_fsleyes.py
@@ -171,7 +171,7 @@ class PreviewPanel(wx.Panel, OptionComponent):
 
             for ext in (".nii", ".nii.gz"):
                 if os.path.exists(meanfile + ext):
-                    self._preview_data = nib.load(meanfile + ext).get_data()
+                    self._preview_data = nib.load(meanfile + ext).get_fdata()
 
             if self._preview_data is None:
                 raise RuntimeError("Could not load output from asl_file")

--- a/python/oxford_asl/gui/preview_mpl.py
+++ b/python/oxford_asl/gui/preview_mpl.py
@@ -103,7 +103,7 @@ class PreviewPanel(wx.Panel, OptionComponent):
 
             for ext in (".nii", ".nii.gz"):
                 if os.path.exists(meanfile + ext):
-                    self._preview_data = nib.load(meanfile + ext).get_data()
+                    self._preview_data = nib.load(meanfile + ext).get_fdata()
 
             if self._preview_data is None:
                 raise RuntimeError("Could not load output from asl_file")


### PR DESCRIPTION
Hi @mcraig-ibme, this is just a small fix to make oxford_asl compatible with nibabel 5 - `Nifti1Image.get_data` now raises an error, so needs to be replaced with `get_fdata` (or `np.asanyarray(img.dataobj)`, if you want to preserve the native image data type). Thanks!